### PR TITLE
Don't use typographic quotes in code examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,10 +222,10 @@
           <h4 class="heading-2 section-heading">CocoaPods</h4>
           <p class="bodytext">Cocoapods 1.1.0.rc.3 or newer version must be used. Specify Eureka into your project’s Podfile:</p>
           <div class="codebox">
-            <p class="bodytext codetext">source ‘https://github.com/CocoaPods/Specs.git’
-              <br>platform :ios, ‘9.0’
+            <p class="bodytext codetext">source 'https://github.com/CocoaPods/Specs.git'
+              <br>platform :ios, '9.0'
               <br>use_frameworks!
-              <br> pod ‘Eureka’, ‘~&gt; 2.0.0-beta.1’
+              <br> pod 'Eureka', '~&gt; 2.0.0-beta.1'
             </p>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -233,7 +233,7 @@
           <h4 class="heading-2 section-heading">Carthage</h4>
           <p class="bodytext">Carthage is a simple, decentralized dependency manager for Cocoa. Just specify Eureka into your project’s Cartfile:</p>
           <div class="codebox">
-            <p class="bodytext codetext">github “xmartlabs/Eureka” ~&gt; 2.0.0</p>
+            <p class="bodytext codetext">github "xmartlabs/Eureka" ~&gt; 2.0.0</p>
           </div>
         </div>
         <div class="manually" data-ix="fade-in-left-scroll-in">


### PR DESCRIPTION
While typographic quotes `“ ”` look pretty, they can cause issues with tired people blindly copy and pasting the `Cartfile` and `Podfile` examples 😄 